### PR TITLE
Inverte a ordem para substituir os duplos primeiro

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,7 +23,7 @@ namespace cebolinha
             Console.ForegroundColor=ConsoleColor.DarkMagenta;
             string frase = Console.ReadLine();
             Console.Clear();
-            Console.WriteLine(frase = frase.Replace("r", "l").Replace("rr","l").Replace("RR","L").Replace("R","L"));
+            Console.WriteLine(frase = frase.Replace("rr", "l").Replace("r","l").Replace("RR","L").Replace("R","L"));
             Console.ForegroundColor=ConsoleColor.DarkBlue;
             Console.WriteLine(""+nome+", obrigada por ajudar. Agora você é o cebolinha :D ");
             Console.ResetColor();


### PR DESCRIPTION
Dado:

Ferreira.

"Ferreira"..Replace("r", "l").Replace("rr","l").Replace("RR","L").Replace("R","L")
= 
"Felleila", pois, o primeiro replace ("r") substituiu tudo.

Com a correção:
"Ferreira"..Replace("rr", "l").Replace("r","l").Replace("RR","L").Replace("R","L")
= 
"Feleila", pois, o primeiro replace ("rr") substituiu apenas o duplo r.